### PR TITLE
Wait for all filesystems to be available before starting docker (on upstart)

### DIFF
--- a/templates/default/upstart/docker.conf.erb
+++ b/templates/default/upstart/docker.conf.erb
@@ -1,6 +1,6 @@
 description "Docker daemon"
 
-start on (local-filesystems and net-device-up IFACE!=lo)
+start on (filesystem and net-device-up IFACE!=lo)
 stop on runlevel [!2345]
 limit nofile 524288 1048576
 limit nproc 524288 1048576


### PR DESCRIPTION
My proposed fix for #536.

There is no integration test, but if there was a simple typo in the init file then the docker daemon would not be running at all, so I think this is quite safe.