### PR TITLE
Chef fails if docker v1.9.x service already started

### DIFF
--- a/templates/default/upstart/docker.conf.erb
+++ b/templates/default/upstart/docker.conf.erb
@@ -57,7 +57,7 @@ post-start script
         RESPONSE=`<%= @docker_cmd %> ps 2>&1 | head -n 1`
         local mret=$?
         if [ $mret -eq 0 ] \
-        || [ `echo $RESPONSE | grep -q "Is your docker"` ]; then
+        || [ `echo $RESPONSE | grep -qi "docker daemon"` ]; then
             RUNNING=0
         fi
         return $RUNNING


### PR DESCRIPTION
See issue https://github.com/someara/chef-docker/issues/545

This will fix the return code for the Upstart job if already running.

Please test with Docker v1.8.3 as I don't have access to a box with it immediately.

cc @someara for review :smile:

PS: Your work is much appreciated as always #hugops 